### PR TITLE
Update Electrocardiogram Mapping

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.4.0")),
-        .package(url: "https://github.com/StanfordBDHG/CardinalKit", .upToNextMinor(from: "0.3.3")),
+        .package(url: "https://github.com/StanfordBDHG/CardinalKit", .upToNextMinor(from: "0.3.5")),
         .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.2"))
     ],
     targets: [

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -7,9 +7,9 @@
 //
 
 
-import SwiftUI
 @preconcurrency import FHIR
 import HealthKitDataSource
+import SwiftUI
 
 
 struct ContentView: View {

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -1,0 +1,68 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+import SwiftUI
+@preconcurrency import FHIR
+import HealthKitDataSource
+
+
+struct ContentView: View {
+    @EnvironmentObject var healthKitComponent: HealthKit<FHIR>
+    @EnvironmentObject var fhirStandard: FHIR
+    @State var testState = "Awaiting Check ..."
+    
+    
+    var body: some View {
+        VStack {
+            Button("HealthKit Authorization") {
+                _Concurrency.Task {
+                    try await healthKitComponent.askForAuthorization()
+                }
+            }
+            Button("Pull HealthKit Data") {
+                _Concurrency.Task {
+                    await healthKitComponent.triggerDataSourceCollection()
+                }
+            }
+            Button("Check ECG Data") {
+                _Concurrency.Task {
+                    let observations = await fhirStandard.resources(resourceType: Observation.self)
+                    
+                    guard observations.count == 3 else {
+                        testState = "Unexpected number of observations: \(observations.count)"
+                        return
+                    }
+                    
+                    testState = "Passed"
+                }
+            }
+            Button("Check Stepcount Data") {
+                _Concurrency.Task {
+                    let observations = await fhirStandard.resources(resourceType: Observation.self)
+                    
+                    guard observations.count == 1 else {
+                        testState = "Unexpected number of observations: \(observations.count)"
+                        return
+                    }
+                    
+                    testState = "Passed"
+                }
+            }
+            Text(testState)
+        }
+            .navigationTitle("Tests")
+    }
+}
+
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Tests/UITests/TestApp/TestApp.entitlements
+++ b/Tests/UITests/TestApp/TestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+</dict>
+</plist>

--- a/Tests/UITests/TestApp/TestApp.entitlements.license
+++ b/Tests/UITests/TestApp/TestApp.entitlements.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -6,15 +6,20 @@
 // SPDX-License-Identifier: MIT
 //
 
-import CardinalKitHealthKitToFHIRAdapter
 import SwiftUI
 
 
 @main
 struct UITestsApp: App {
+    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate
+    
+    
     var body: some Scene {
         WindowGroup {
-            Text("CardinalKitHealthKitToFHIRAdapter")
+            NavigationStack {
+                ContentView()
+            }
+                .cardinalKit(appDelegate)
         }
     }
 }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -7,10 +7,10 @@
 //
 
 import CardinalKit
-@preconcurrency import FHIR
-import HealthKitDataSource
-@preconcurrency import HealthKit
 import CardinalKitHealthKitToFHIRAdapter
+@preconcurrency import FHIR
+@preconcurrency import HealthKit
+import HealthKitDataSource
 import SwiftUI
 
 

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import CardinalKit
+@preconcurrency import FHIR
+import HealthKitDataSource
+@preconcurrency import HealthKit
+import CardinalKitHealthKitToFHIRAdapter
+import SwiftUI
+
+
+class TestAppDelegate: CardinalKitAppDelegate {
+    override var configuration: Configuration {
+        Configuration(standard: FHIR()) {
+            if HKHealthStore.isHealthDataAvailable() {
+                HealthKit {
+                    CollectSample(HKQuantityType(.stepCount))
+                    CollectSample(HKQuantityType.electrocardiogramType())
+                    CollectSamples(Set(HKElectrocardiogram.correlatedSymptomTypes))
+                } adapter: {
+                    HealthKitToFHIRAdapter()
+                }
+            }
+        }
+    }
+}

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -7,6 +7,8 @@
 //
 
 import XCTest
+import XCTestExtensions
+import XCTHealthKit
 
 
 class TestAppUITests: XCTestCase {
@@ -17,10 +19,48 @@ class TestAppUITests: XCTestCase {
     }
     
     
-    func testCardinalKitHealthKitToFHIRAdapterTests() throws {
+    func testCardinalKitHealthKitToFHIRAdapterWithECG() throws {
         let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        
+        XCTAssert(app.buttons["HealthKit Authorization"].waitForExistence(timeout: 2))
+        app.buttons["HealthKit Authorization"].tap()
+        
+        try app.handleHealthKitAuthorization()
+        
+        try exitAppAndOpenHealth(.electrocardiograms)
+        
         app.launch()
         
-        XCTAssert(app.staticTexts["CardinalKitHealthKitToFHIRAdapter"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["Pull HealthKit Data"].waitForExistence(timeout: 2))
+        app.buttons["Pull HealthKit Data"].tap()
+        
+        sleep(2)
+        
+        XCTAssert(app.buttons["Check ECG Data"].waitForExistence(timeout: 2))
+        app.buttons["Check ECG Data"].tap()
+    }
+    
+    
+    func testCardinalKitHealthKitToFHIRAdapterWithSteps() throws {
+        let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        
+        XCTAssert(app.buttons["HealthKit Authorization"].waitForExistence(timeout: 2))
+        app.buttons["HealthKit Authorization"].tap()
+        
+        try app.handleHealthKitAuthorization()
+        
+        try exitAppAndOpenHealth(.steps)
+        
+        app.launch()
+        
+        XCTAssert(app.buttons["Pull HealthKit Data"].waitForExistence(timeout: 2))
+        app.buttons["Pull HealthKit Data"].tap()
+        
+        sleep(2)
+        
+        XCTAssert(app.buttons["Check Stepcount Data"].waitForExistence(timeout: 2))
+        app.buttons["Check Stepcount Data"].tap()
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -10,6 +10,13 @@
 		2F34F72729B6A327000CDE98 /* CardinalKitHealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2F34F72629B6A327000CDE98 /* CardinalKitHealthKitToFHIRAdapter */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* TestAppUITests.swift */; };
+		2F9F4D6929B6AD7100ABE259 /* FHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D6829B6AD7100ABE259 /* FHIR */; };
+		2F9F4D6D29B6AD7100ABE259 /* HealthKitDataSource in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D6C29B6AD7100ABE259 /* HealthKitDataSource */; };
+		2F9F4D6F29B6AD7100ABE259 /* HealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D6E29B6AD7100ABE259 /* HealthKitToFHIRAdapter */; };
+		2F9F4D7229B6B0DD00ABE259 /* XCTHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D7129B6B0DD00ABE259 /* XCTHealthKit */; };
+		2F9F4D7429B6B91D00ABE259 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F4D7329B6B91D00ABE259 /* TestAppDelegate.swift */; };
+		2F9F4D7629B6B9E800ABE259 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F4D7529B6B9E800ABE259 /* ContentView.swift */; };
+		2F9F4D7929B6BBDF00ABE259 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D7829B6BBDF00ABE259 /* XCTestExtensions */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 /* End PBXBuildFile section */
 
@@ -29,6 +36,9 @@
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F8A431229130A8C005D2B8F /* TestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
+		2F9F4D7329B6B91D00ABE259 /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
+		2F9F4D7529B6B9E800ABE259 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		2F9F4D7A29B6BDD300ABE259 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -38,7 +48,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F9F4D6D29B6AD7100ABE259 /* HealthKitDataSource in Frameworks */,
 				2F34F72729B6A327000CDE98 /* CardinalKitHealthKitToFHIRAdapter in Frameworks */,
+				2F9F4D6929B6AD7100ABE259 /* FHIR in Frameworks */,
+				2F9F4D6F29B6AD7100ABE259 /* HealthKitToFHIRAdapter in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -46,6 +59,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F9F4D7229B6B0DD00ABE259 /* XCTHealthKit in Frameworks */,
+				2F9F4D7929B6BBDF00ABE259 /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +91,10 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				2F9F4D7A29B6BDD300ABE259 /* TestApp.entitlements */,
+				2F9F4D7329B6B91D00ABE259 /* TestAppDelegate.swift */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
+				2F9F4D7529B6B9E800ABE259 /* ContentView.swift */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 			);
 			path = TestApp;
@@ -115,6 +133,9 @@
 			name = TestApp;
 			packageProductDependencies = (
 				2F34F72629B6A327000CDE98 /* CardinalKitHealthKitToFHIRAdapter */,
+				2F9F4D6829B6AD7100ABE259 /* FHIR */,
+				2F9F4D6C29B6AD7100ABE259 /* HealthKitDataSource */,
+				2F9F4D6E29B6AD7100ABE259 /* HealthKitToFHIRAdapter */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -134,6 +155,10 @@
 				2F6D13AE28F5F386007C25D6 /* PBXTargetDependency */,
 			);
 			name = TestAppUITests;
+			packageProductDependencies = (
+				2F9F4D7129B6B0DD00ABE259 /* XCTHealthKit */,
+				2F9F4D7829B6BBDF00ABE259 /* XCTestExtensions */,
+			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -166,6 +191,11 @@
 				Base,
 			);
 			mainGroup = 2F6D138928F5F384007C25D6;
+			packageReferences = (
+				2F9F4D6729B6AD7100ABE259 /* XCRemoteSwiftPackageReference "CardinalKit" */,
+				2F9F4D7029B6B0DD00ABE259 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
+				2F9F4D7729B6BBDF00ABE259 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
+			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -199,7 +229,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F9F4D7429B6B91D00ABE259 /* TestAppDelegate.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
+				2F9F4D7629B6B9E800ABE259 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,6 +373,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -348,6 +381,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "The Test App requires access to the HealthKit data to perform the tests.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -358,7 +392,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.templatepackage.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -372,6 +406,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -379,6 +414,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "The Test App requires access to the HealthKit data to perform the tests.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -389,7 +425,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.templatepackage.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -407,7 +443,7 @@
 				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.CardinalKitHealthKitToFHIRAdapterTests.testappuitests;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -426,7 +462,7 @@
 				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.CardinalKitHealthKitToFHIRAdapterTests.testappuitests;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -501,6 +537,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -508,6 +545,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "The Test App requires access to the HealthKit data to perform the tests.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -518,7 +556,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.templatepackage.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -536,7 +574,7 @@
 				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.CardinalKitHealthKitToFHIRAdapterTests.testappuitests;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cardinalkit.healthkittofhiradapter.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -581,10 +619,62 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		2F9F4D6729B6AD7100ABE259 /* XCRemoteSwiftPackageReference "CardinalKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordBDHG/CardinalKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.5;
+			};
+		};
+		2F9F4D7029B6B0DD00ABE259 /* XCRemoteSwiftPackageReference "XCTHealthKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.3;
+			};
+		};
+		2F9F4D7729B6BBDF00ABE259 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		2F34F72629B6A327000CDE98 /* CardinalKitHealthKitToFHIRAdapter */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CardinalKitHealthKitToFHIRAdapter;
+		};
+		2F9F4D6829B6AD7100ABE259 /* FHIR */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F9F4D6729B6AD7100ABE259 /* XCRemoteSwiftPackageReference "CardinalKit" */;
+			productName = FHIR;
+		};
+		2F9F4D6C29B6AD7100ABE259 /* HealthKitDataSource */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F9F4D6729B6AD7100ABE259 /* XCRemoteSwiftPackageReference "CardinalKit" */;
+			productName = HealthKitDataSource;
+		};
+		2F9F4D6E29B6AD7100ABE259 /* HealthKitToFHIRAdapter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F9F4D6729B6AD7100ABE259 /* XCRemoteSwiftPackageReference "CardinalKit" */;
+			productName = HealthKitToFHIRAdapter;
+		};
+		2F9F4D7129B6B0DD00ABE259 /* XCTHealthKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F9F4D7029B6B0DD00ABE259 /* XCRemoteSwiftPackageReference "XCTHealthKit" */;
+			productName = XCTHealthKit;
+		};
+		2F9F4D7829B6BBDF00ABE259 /* XCTestExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F9F4D7729B6BBDF00ABE259 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			productName = XCTestExtensions;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
# Update Electrocardiogram Mapping

## :recycle: Current situation & Problem
- The current electrocardiogram mapping does not automatically collect symptoms and raw voltage data for the [CardinalKitHealthKitToFHIRAdapter](https://github.com/StanfordBDHG/CardinalKitHealthKitToFHIRAdapter).

## :bulb: Proposed solution
- This PR adds the collection of symptoms by asking for the appropriate permissions in the HealthKit module
- The full raw voltage measurements are now attached to the encoded FHIR response

Thank you to @ckunchur for the input and reporting the bugs!

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

